### PR TITLE
Add BAWAG PSK extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Pull Requests für fehlende Erweiterungen werden gern gesehen.
 * [Whitebox](https://github.com/mirkowein/moneymoney-whitebox) von [mirkowein](https://github.com/mirkowein)
 
 ### Kontostand- und Umsatzabfrage
+* [BAWAG PSK](https://github.com/frittex/moneymoney-bawagpsk) von [frittex](https://github.com/frittex)
 * [Lloyds Bank UK 🔒](https://github.com/gdelmas/LloydsBank-MoneyMoney) von [gdelmas](https://github.com/gdelmas)
 * [Payback 🔒](https://github.com/gdelmas/LloydsBank-MoneyMoney) von [gdelmas](https://github.com/gdelmas)
 * [PayLife MasterCard RED 🔒](https://github.com/phpwutz/moneymoney-mastercardred-ext) von [phpwutz](https://github.com/phpwutz)


### PR DESCRIPTION
Support for accounts at the Austrian BAWAG PSK.